### PR TITLE
Update package.json

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -63,6 +63,9 @@
         "compact": true,
         "connectionType": "local",
         "dataSource": "push",
+        "adminUI": {
+            "config": "materialize"
+        },
         "dependencies": [
             {
                 "js-controller": ">=5.0.19"

--- a/package.json
+++ b/package.json
@@ -15,10 +15,7 @@
     }
   ],
   "homepage": "https://github.com/phifogg/ioBroker.sainlogic",
-  "licenseInformation": {
-          "type": "free",
-          "license": "MIT"
-        },
+  "license": "MIT",
   "keywords": [
     "ioBroker",
     "weather",


### PR DESCRIPTION
- change at package,json:
  revert to "license":"MIT"
  licenseInformation is a new attribute at io-package.json only. If some checker text refers to package.json (instead io-package.json) please let me know

- change io-package.json
  you removed materialize:true but did not add adminUI:{conifg:materialize} which is the new format.
  I'm sorry that the checker text was suboptimal. I've adapted it.

Merging this PR should fix the last errors.

**THANKS a lot for the ultrafast reaction.** Please check the functionality of the adapter - especially the functionality of the adminUI after merging before releasing a new version (or immidiatly afterwards). 

NOTE: no hurry for the next release is required. The changes to io-package.json will be effective immidiatly as the repobuilder updated from latest repo sources. So I will release 0.11.4 afte rthis PR is merged (and hopefully passing the Github Standard tests)