### PR TITLE
Update test_and_release.yml - fix branch name

### DIFF
--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -5,7 +5,7 @@ name: Test and Release
 on:
   push:
     branches:
-      - "main"
+      - "master"
     tags:
       # normal versions
       - "v[0-9]+.[0-9]+.[0-9]+"


### PR DESCRIPTION
Your test-and-release workflow referred to branch main but defautl branch is name master at this repo.