### PR TITLE
Fix display name for units to use correct superscript

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -955,7 +955,7 @@ const DATAFIELDS = [
         unit_config: 'unit_solar',
         units: [
             {
-                display_name: 'W/m2',
+                display_name: 'W/m²',
                 display_conversion: lx_to_wm2,
                 main_unit_conversion: wm2_to_lx,
             },


### PR DESCRIPTION
Fix warn message

No unit definition found for solarradiation and target unit 'W/m²', using raw value